### PR TITLE
updating CTAs for packages

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Context
+
+[provide more detailed introduction to the issue itself and why it is relevant]
+
+## Process
+
+[ordered list the process to finding and recreating the issue, example below]
+
+1. User goes to delete a dataset (to save space or whatever)
+2. User gets popup modal warning
+3. User deletes and it's lost forever
+
+## Expected result
+
+[describe what you would expect to have resulted from this process]
+
+## Current result
+
+[describe what you you currently experience from this process, and thereby explain the bug]
+
+## Screenshot
+
+[if relevant, include a screenshot]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Done
+
+[List of work items including drive-bys]
+
+## QA
+
+[List of steps to QA the new features or prove the bug has been resolved]
+
+## Issue / Card
+
+[List of links to Github issues/bugs and cards if needed]
+
+Top tip: If this is related to a Github issue, use the keyword "Fixes" to auto-resolve that issue when this PR is merged.
+
+e.g. `Fixes #1`
+
+## Screenshots
+
+[if relevant, include a screenshot]

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ layout: default
             <div class="box__img-wrap">
               <img class="box__img" src="https://assets.ubuntu.com/v1/887474d1-ubuntu.svg" alt="Ubuntu logo">
             </div>
-            <p class="box__txt">Get Ubuntu cloud images ›</p>
+            <p class="box__txt">Get packages ›</p>
           </a>
       </li>
       <li class="box three-col">
@@ -79,7 +79,7 @@ layout: default
             <div class="box__img-wrap">
               <img class="box__img" src="https://assets.ubuntu.com/v1/e0b23092-archlinux.svg" alt="Arch Linux logo">
             </div>
-            <p class="box__txt">Get Ubuntu cloud images ›</p>
+            <p class="box__txt">Get packages ›</p>
           </a>
 
       </li>
@@ -88,7 +88,7 @@ layout: default
             <div class="box__img-wrap">
               <img class="box__img" src="https://assets.ubuntu.com/v1/31bd1765-centos.svg" alt="Centos logo">
             </div>
-            <p class="box__txt">Get Ubuntu cloud images ›</p>
+            <p class="box__txt">Get packages ›</p>
           </a>
       </li>
 
@@ -97,7 +97,7 @@ layout: default
             <div class="box__img-wrap">
               <img class="box__img" src="https://assets.ubuntu.com/v1/6947a9e3-redhat.svg" alt="RedHat logo">
             </div>
-            <p class="box__txt">Get Ubuntu cloud images ›</p>
+            <p class="box__txt">Get packages ›</p>
           </a>
       </li>
 
@@ -106,7 +106,7 @@ layout: default
             <div class="box__img-wrap">
               <img class="box__img" src="https://assets.ubuntu.com/v1/6fa4b259-freebsd.png" alt="FreeBSD logo">
             </div>
-            <p class="box__txt">Get Ubuntu cloud images ›</p>
+            <p class="box__txt">Get packages ›</p>
           </a>
       </li>
 
@@ -115,7 +115,7 @@ layout: default
             <div class="box__img-wrap">
               <img class="box__img" src="https://assets.ubuntu.com/v1/1a53bedd-fedora.svg" alt="Fedora logo">
             </div>
-            <p class="box__txt">Get Ubuntu cloud images ›</p>
+            <p class="box__txt">Get packages ›</p>
           </a>
       </li>
 
@@ -124,7 +124,7 @@ layout: default
             <div class="box__img-wrap">
               <img class="box__img" src="https://assets.ubuntu.com/v1/2235d892-gentoo.png" alt="Gentoo logo">
             </div>
-            <p class="box__txt">Get Ubuntu cloud images ›</p>
+            <p class="box__txt">Get packages ›</p>
           </a>
       </li>
 
@@ -133,7 +133,7 @@ layout: default
             <div class="box__img-wrap">
               <img class="box__img" src="https://assets.ubuntu.com/v1/2e497b2e-opensuse.svg" alt="OpenSUSE logo">
             </div>
-            <p class="box__txt">Get Ubuntu cloud images ›</p>
+            <p class="box__txt">Get packages ›</p>
           </a>
       </li>
     </ul>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "vanilla-framework": "0.0.60"
   },
   "devDependencies": {
-    "gulp-gh-pages": "^0.5.4",
-    "gulp-jekyll": "0.0.0"
+    "gulp-gh-pages": "^0.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "vanilla-framework": "0.0.60"
   },
   "devDependencies": {
-    "gulp-gh-pages": "^0.5.4"
+    "gulp-gh-pages": "^0.5.4",
+    "gulp-jekyll": "0.0.0"
   }
 }


### PR DESCRIPTION
based on request from Dustin Kirkland at Austin Cloud Sprint - 4 May 2016

Done
===

* updated cta's from 'Get Ubuntu cloud images >' to 'Get packages >'
* updated the [copy doc](https://docs.google.com/document/d/19NkJMlHv3Jebm-A8Ol1eCxjDTPrMyhfUCWYDHioGBO0/edit)

QA
===

build site and review, I couldn't get the 'gulp' to build the site with jekyll.

